### PR TITLE
Fixed issue with ngOnDestroy with this.parent

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -284,7 +284,8 @@ export class Tabs extends Ion implements AfterViewInit, RootNode {
 
   ngOnDestroy() {
     this._resizeObs && this._resizeObs.unsubscribe();
-    this.parent.unregisterChildNav(this);
+    if (this.parent) 
+      this.parent.unregisterChildNav(this);
   }
 
   /**


### PR DESCRIPTION
this.parent could be undefined (since it's optional in the constructor).  However, ngOnDestroy's default behavior assumes it will be present.  This fix makes the call to unregisterChildNav dependent on parent being defined.

#### Short description of what this resolves:
Problem with this.parent being undefined in ngOnDestroy

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #
